### PR TITLE
會員頁面修正

### DIFF
--- a/src/component/AdminArticleCard/Admin_ArticleCard.jsx
+++ b/src/component/AdminArticleCard/Admin_ArticleCard.jsx
@@ -9,31 +9,15 @@ import { alertMsgForCancelFavorites } from "../../utils/alertMsg";
 import LoadingSpinner from '../../component/LoadingSpinner/LoadingSpinner';
 
 
-const Admin_ArticleCard = () => {
+const Admin_ArticleCard = ({
+  collectionData,
+  setCollectionData,
+  collectionDataList,
+  setCurrentPage
+}) => {
   const { isAuthorized, id, username, token } = useSelector(state => state.auth);
-  const [favorites, setFavorites] = useState([]);
-  const [isLoading,setIsLoading] = useState(false);
-  useEffect(() => {
-    (async () => {
-      if (!token) {
-        Swal.fire(alertMsgForVerify);
-        return;
-      };
-      try {
-        setIsLoading(true);
-        const res = await axios.get(`${VITE_API_BASE_URL}/posts/favorites`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        });
-        setFavorites(res.data.data);
-      } catch (error) {
-        console.log(error);
-      } finally {
-        setIsLoading(false);
-      };
-    })();
-  }, []);
+  const [collection, setCollection] = useState([collectionData]);
+  const [isLoading, setIsLoading] = useState(false);
   const cancelFavorites = async (id) => {
     if (!token) {
       Swal.fire(alertMsgForVerify);
@@ -47,85 +31,84 @@ const Admin_ArticleCard = () => {
         },
       });
       if (res.data.status === "success") {
-        setFavorites((prevFavorites) => prevFavorites.filter((item) => item.id !== id));
+        const updatedCollection = collectionDataList.filter((item) => item.id !== id);
+        setCollectionData(updatedCollection);
+        const newTotalPages = Math.ceil(updatedCollection.length / 10);
+        setCurrentPage((prevPage) => (prevPage > newTotalPages ? newTotalPages : prevPage));
       }
       Swal.fire(alertMsgForCancelFavorites);
     } catch (error) {
       console.log(error);
-    }finally{
+    } finally {
       setIsLoading(false);
     }
   }
   return (
     <>
-    {isLoading && <LoadingSpinner />}
-      {favorites.length === 0 ? (
-        <h3 className="mt-3 text-gray">目前沒有收藏的文章</h3>
-      ) : (
-        favorites.map((item) => {
-          const extractFirstParagraphText = (htmlContent) => { //取得第一段的<p>內的文字
-            const parser = new DOMParser();
-            const doc = parser.parseFromString(htmlContent, "text/html");
-            const firstParagraph = doc.querySelector("p");
-            if (!firstParagraph) return "";
-            return firstParagraph.textContent.trim();
-          };
-          const formDate = (str) => {
-            const date = new Date(str);
-            return date.toLocaleDateString();
-          };
-          return (
-            <div className="admin_articleCard card border-gray_light p-3  mb-5 rounded-3" key={item.id}>
-              <div className="row flex-column-reverse flex-lg-row">
-                <div className="col-lg-8">
-                  <div className="card-body p-0 d-flex flex-column justify-content-between h-100">
-                    <div>
-                      <h5>
-                        <Link to={`/article/${item.id}`} className="card-title text-truncate-2lines fw-bold mb-3 text-primary">
-                          {item.title}
-                        </Link>
-                      </h5>
-                      <p className="card-text mb-5 text-truncate-2lines">
-                        {item.description || extractFirstParagraphText(item.content)}
-                      </p>
+      {isLoading && <LoadingSpinner />}
+      {collection.map((item) => {
+        const extractFirstParagraphText = (htmlContent) => { //取得第一段的<p>內的文字
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(htmlContent, "text/html");
+          const firstParagraph = doc.querySelector("p");
+          if (!firstParagraph) return "";
+          return firstParagraph.textContent.trim();
+        };
+        const formDate = (str) => {
+          const date = new Date(str);
+          return date.toLocaleDateString();
+        };
+        return (
+          <div className="admin_articleCard card border-gray_light p-3  mb-5 rounded-3" key={item.id}>
+            <div className="row flex-column-reverse flex-lg-row">
+              <div className="col-lg-8">
+                <div className="card-body p-0 d-flex flex-column justify-content-between h-100">
+                  <div>
+                    <h5>
+                      <Link to={`/article/${item.id}`} className="card-title text-truncate-2lines fw-bold mb-3 text-primary">
+                        {item.title}
+                      </Link>
+                    </h5>
+                    <p className="card-text mb-5 text-truncate-2lines">
+                      {item.description || extractFirstParagraphText(item.content)}
+                    </p>
+                  </div>
+                  <div className="adminArticleCardFooter d-flex  align-items-center gap-3">
+                    <p className="text-gray">{formDate(item.updated_at)}</p>
+                    <div className="d-flex text-gray gap-1">
+                      <p>{item.likes_count}</p>
+                      <span className="material-symbols-outlined">
+                        favorite
+                      </span>
                     </div>
-                    <div className="adminArticleCardFooter d-flex  align-items-center gap-3">
-                      <p className="text-gray">{formDate(item.updated_at)}</p>
-                      <div className="d-flex text-gray gap-1">
-                        <p>{item.likes_count}</p>
-                        <span className="material-symbols-outlined">
-                          favorite
-                        </span>
-                      </div>
-                      <div className="d-flex text-gray gap-1">
-                        <p>{item.comments_count}</p>
-                        <span className="material-symbols-outlined">
-                          chat_bubble
-                        </span>
-                      </div>
-                      <div className="d-flex text-gray gap-1">
-                        <p>{item.favorites_count}</p>
-                        <span class="material-symbols-outlined text-primary" style={{ cursor: "pointer" }} onClick={() => cancelFavorites(item.id)}>
-                          bookmark
-                        </span>
-                      </div>
+                    <div className="d-flex text-gray gap-1">
+                      <p>{item.comments_count}</p>
+                      <span className="material-symbols-outlined">
+                        chat_bubble
+                      </span>
+                    </div>
+                    <div className="d-flex text-gray gap-1">
+                      <p>{item.favorites_count}</p>
+                      <span className="material-symbols-outlined text-primary" style={{ cursor: "pointer" }} onClick={() => cancelFavorites(item.id)}>
+                        bookmark
+                      </span>
                     </div>
                   </div>
                 </div>
-                <div className="col-lg-4">
-                  {item.image_url && (
-                    <img
-                      src={item.image_url}
-                      className="card-img-top rounded-1 mb-5"
-                      alt="articleImg"
-                    />
-                  )}
-                </div>
+              </div>
+              <div className="col-lg-4">
+                {item.image_url && (
+                  <img
+                    src={item.image_url}
+                    className="card-img-top rounded-1 mb-5"
+                    alt="articleImg"
+                  />
+                )}
               </div>
             </div>
-          )
-        })
-      )}
+          </div>
+        )
+      })}
     </>
   );
 };

--- a/src/component/AdminArticleCard/Admin_ArticleCard.jsx
+++ b/src/component/AdminArticleCard/Admin_ArticleCard.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useSelector } from "react-redux";
 import axios from "axios";
+import PropTypes from "prop-types";
 const { VITE_API_BASE_URL } = import.meta.env;
 import { Link } from "react-router-dom";
 import Swal from "sweetalert2";
@@ -8,15 +9,14 @@ import { alertMsgForVerify } from "../../utils/alertMsg";
 import { alertMsgForCancelFavorites } from "../../utils/alertMsg";
 import LoadingSpinner from '../../component/LoadingSpinner/LoadingSpinner';
 
-
 const Admin_ArticleCard = ({
   collectionData,
   setCollectionData,
   collectionDataList,
   setCurrentPage
 }) => {
-  const { isAuthorized, id, username, token } = useSelector(state => state.auth);
-  const [collection, setCollection] = useState([collectionData]);
+  const { token } = useSelector(state => state.auth);
+  const [collection] = useState([collectionData]);
   const [isLoading, setIsLoading] = useState(false);
   const cancelFavorites = async (id) => {
     if (!token) {
@@ -111,6 +111,13 @@ const Admin_ArticleCard = ({
       })}
     </>
   );
+};
+
+Admin_ArticleCard.propTypes = {
+  collectionData: PropTypes.object.isRequired,
+  setCollectionData: PropTypes.func.isRequired,
+  collectionDataList: PropTypes.array.isRequired,
+  setCurrentPage: PropTypes.func.isRequired,
 };
 
 export default Admin_ArticleCard;

--- a/src/component/AdminRevenueChart/AdminRevenueChart.jsx
+++ b/src/component/AdminRevenueChart/AdminRevenueChart.jsx
@@ -1,6 +1,7 @@
-import React, { useEffect } from "react";
+import  { useEffect } from "react";
 import c3 from "c3";
 import "c3/c3.css";
+import PropTypes from "prop-types";
 
 const AdminRevenueChart = ({ revenueData }) => {
   useEffect(() => {
@@ -60,6 +61,10 @@ const AdminRevenueChart = ({ revenueData }) => {
       <div id="revenue-chart"></div>
     </div>
   );
+};
+
+AdminRevenueChart.propTypes = {
+  revenueData: PropTypes.arrayOf(PropTypes.number).isRequired,
 };
 
 export default AdminRevenueChart;

--- a/src/component/AdminViewCount/AdminViewCount.jsx
+++ b/src/component/AdminViewCount/AdminViewCount.jsx
@@ -1,10 +1,10 @@
 import dayjs from "dayjs";
-
+import PropTypes from "prop-types";
 
 const AdminViewCount = ({article}) => {
   return (
     <>
-      <li key={article.id} className="d-md-grid d-flex justify-content-between mb-5">
+      <li key={Number(article.id)} className="d-md-grid d-flex justify-content-between mb-5">
         <div>
           <p className="clickCount_body-title mb-2">{article.title}</p>
           <p className="text-gray d-md-none">{dayjs(article.created_at).format("YYYY-MM-DD")}</p>
@@ -15,5 +15,14 @@ const AdminViewCount = ({article}) => {
     </>
   )
 }
+
+AdminViewCount.propTypes = {
+  article: PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    title: PropTypes.string.isRequired,
+    created_at: PropTypes.string.isRequired,
+    views_count: PropTypes.number.isRequired,
+  }).isRequired,
+};
 
 export default AdminViewCount;

--- a/src/component/AdminViewCount/AdminViewCount.jsx
+++ b/src/component/AdminViewCount/AdminViewCount.jsx
@@ -1,0 +1,19 @@
+import dayjs from "dayjs";
+
+
+const AdminViewCount = ({article}) => {
+  return (
+    <>
+      <li key={article.id} className="d-md-grid d-flex justify-content-between mb-5">
+        <div>
+          <p className="clickCount_body-title mb-2">{article.title}</p>
+          <p className="text-gray d-md-none">{dayjs(article.created_at).format("YYYY-MM-DD")}</p>
+        </div>
+        <p className="text-gray d-none d-md-block">{dayjs(article.created_at).format("YYYY-MM-DD")}</p>
+        <p>{article.views_count.toLocaleString()}</p>
+      </li>
+    </>
+  )
+}
+
+export default AdminViewCount;

--- a/src/component/SubscriptionCard/SubscriptionHistoryCard.jsx
+++ b/src/component/SubscriptionCard/SubscriptionHistoryCard.jsx
@@ -29,7 +29,7 @@ const SubscriptionHistoryCard = ({ payerId, paymentDate, amount }) => {
           <p className="fw-bold">
             {new Date(paymentDate).toLocaleDateString("fr-CA")}
           </p>
-          <button className="btn btn-primary-hover text-light" style={{cursor: 'default'}}>
+          <button className="btn btn-primary-hover text-light w-50" style={{cursor: 'default'}}>
             ${amount}
           </button>
         </div>

--- a/src/page/AdminPage/AdminBackground.jsx
+++ b/src/page/AdminPage/AdminBackground.jsx
@@ -10,7 +10,7 @@ import AdminViewCount from "../../component/AdminViewCount/AdminViewCount";
 
 const AdminBackground = () => {
   const [isLoading,setIsLoading] = useState(false);
-  const { isAuthorized, id, username, token } = useSelector(state => state.auth);
+  const {id,token } = useSelector(state => state.auth);
 
   const [followers, setFollowers] = useState(0); // 訂閱人數
   const [totalViews, setTotalViews] = useState([]);  // 總點閱量
@@ -84,7 +84,7 @@ const AdminBackground = () => {
       };
     };
     fetchData();
-  }, [])
+  }, [id, token])
 
   // 下拉選單數據
   const [monthlyViews, setMonthlyViews] = useState(0); // 月總點閱量
@@ -146,8 +146,6 @@ const AdminBackground = () => {
     setTotalRevenue(total);
   }, [revenue]);
 
-  // 整理營收圖表數據
-  const [monthlyRevenueData, setMonthlyRevenueData] = useState(Array(12).fill(0));
 
   // 圖表年份選擇
   const [selectedYear, setSelectedYear] = useState(dayjs().format("YYYY")); // 預設當前年份
@@ -350,15 +348,6 @@ const AdminBackground = () => {
         <ul className="clickCount_body list-unstyled">
           {currentArticles.length > 0 ? (
             currentArticles.map((article) => (
-              // <li key={article.id} className="d-md-grid d-flex justify-content-between mb-5">
-              //   <div>
-              //     <p className="clickCount_body-title mb-2">{article.title}</p>
-              //     <p className="text-gray d-md-none">{dayjs(article.created_at).format("YYYY-MM-DD")}</p>
-              //   </div>
-              //   <p className="text-gray d-none d-md-block">{dayjs(article.created_at).format("YYYY-MM-DD")}</p>
-              //   <p>{article.views_count.toLocaleString()}</p>
-              // </li>
-
               <AdminViewCount key={article.id} article={article} />
             ))
           ) : (

--- a/src/page/AdminPage/AdminBackground.jsx
+++ b/src/page/AdminPage/AdminBackground.jsx
@@ -6,6 +6,7 @@ const { VITE_API_BASE_URL } = import.meta.env;
 import dayjs from "dayjs";
 import LoadingSpinner from '../../component/LoadingSpinner/LoadingSpinner';
 import AdminRevenueChart from "../../component/AdminRevenueChart/AdminRevenueChart";
+import AdminViewCount from "../../component/AdminViewCount/AdminViewCount";
 
 const AdminBackground = () => {
   const [isLoading,setIsLoading] = useState(false);
@@ -349,14 +350,16 @@ const AdminBackground = () => {
         <ul className="clickCount_body list-unstyled">
           {currentArticles.length > 0 ? (
             currentArticles.map((article) => (
-              <li key={article.id} className="d-md-grid d-flex justify-content-between mb-5">
-                <div>
-                  <p className="clickCount_body-title mb-2">{article.title}</p>
-                  <p className="text-gray d-md-none">{dayjs(article.created_at).format("YYYY-MM-DD")}</p>
-                </div>
-                <p className="text-gray d-none d-md-block">{dayjs(article.created_at).format("YYYY-MM-DD")}</p>
-                <p>{article.views_count.toLocaleString()}</p>
-              </li>
+              // <li key={article.id} className="d-md-grid d-flex justify-content-between mb-5">
+              //   <div>
+              //     <p className="clickCount_body-title mb-2">{article.title}</p>
+              //     <p className="text-gray d-md-none">{dayjs(article.created_at).format("YYYY-MM-DD")}</p>
+              //   </div>
+              //   <p className="text-gray d-none d-md-block">{dayjs(article.created_at).format("YYYY-MM-DD")}</p>
+              //   <p>{article.views_count.toLocaleString()}</p>
+              // </li>
+
+              <AdminViewCount key={article.id} article={article} />
             ))
           ) : (
             <p className="text-gray">目前沒有文章</p>
@@ -366,7 +369,7 @@ const AdminBackground = () => {
         {totalPages > 1 && (
           <ul className="admin-background_pagination list-unstyled d-flex justify-content-center gap-5">
             {Array.from({ length: totalPages }).map((_, i) => (
-              <li key={i} className={i + 1 === currentPage ? "text-primary" : ""} onClick={() => setCurrentPage(i + 1)}>
+              <li style={{ cursor: "pointer" }} key={i} className={i + 1 === currentPage ? "text-primary" : ""} onClick={() => setCurrentPage(i + 1)}>
                 {i + 1}
               </li>
             ))}

--- a/src/page/AdminPage/AdminCollection.jsx
+++ b/src/page/AdminPage/AdminCollection.jsx
@@ -1,10 +1,174 @@
+import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import axios from "axios";
+const { VITE_API_BASE_URL } = import.meta.env;
 import Admin_ArticleCard from "../../component/AdminArticleCard/Admin_ArticleCard";
+import Swal from "sweetalert2";
+import { alertMsgForVerify } from "../../utils/alertMsg";
+import LoadingSpinner from '../../component/LoadingSpinner/LoadingSpinner';
+
 
 const AdminCollection = () => {
+  const { isAuthorized, id, username, token } = useSelector(state => state.auth);
+  const [isLoading, setIsLoading] = useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [collectionData, setCollectionData] = useState([]);
+  useEffect(() => {
+    (async () => {
+      if (!token) {
+        Swal.fire(alertMsgForVerify);
+        return;
+      };
+      try {
+        setIsLoading(true);
+        const res = await axios.get(`${VITE_API_BASE_URL}/posts/favorites`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        setCollectionData(res.data.data);
+      } catch (error) {
+        console.log(error);
+      } finally {
+        setIsLoading(false);
+      };
+    })();
+  }, []);
   return (
     <>
+      {isLoading && <LoadingSpinner />}
       <h1 className="fs-4 fs-md-1 text-primary fw-bold mb-5">我的收藏</h1>
-      <Admin_ArticleCard />
+      {collectionData.length === 0 ? (
+        <h3 className="mt-3 text-gray">目前沒有收藏的文章</h3>
+      ) : (
+        <>
+          {collectionData
+            .slice((currentPage - 1) * 10, currentPage * 10)
+            .map((item) => {
+              return (
+                <Admin_ArticleCard
+                  key={item.id}
+                  collectionData={item}
+                  setCollectionData={setCollectionData} 
+                  collectionDataList={collectionData}  
+                  setCurrentPage={setCurrentPage}     
+                />
+              )
+            })
+          }
+
+          {/* 分頁 */}
+          <nav className="d-none d-lg-block" aria-label="Page navigation">
+            <ul className="hot-article-pagination pagination justify-content-center gap-2 mb-0">
+              <li className="page-item" disable="true">
+                <a
+                  className={`page-link material-symbols-outlined p-0 ps-1 pt-1 rounded-1 ${currentPage === 1 && "disabled"
+                    }`}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setCurrentPage(currentPage - 1);
+                  }}
+                >
+                  arrow_back_ios
+                </a>
+              </li>
+              {Array.from({
+                length: Math.ceil(collectionData.length / 10),
+              }).map((item, index) => {
+                const totalPage = Math.ceil(collectionData.length / 10);
+                if (currentPage - index - 1 <= 2 && currentPage - index - 1 >= -2)
+                  return (
+                    <li className="page-item" key={index}>
+                      <a
+                        className={`page-link rounded-1 p-0 ${currentPage === index + 1 && "active"
+                          }`}
+                        href="#"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setCurrentPage(index + 1);
+                        }}
+                      >
+                        {index + 1}
+                      </a>
+                    </li>
+                  );
+                else if (currentPage < totalPage - 2 && index + 1 === totalPage)
+                  return (
+                    <Fragment key={index}>
+                      <li className="page-item">
+                        <a
+                          className={`page-link rounded-1 p-0`}
+                          href="#"
+                          onClick={(e) => {
+                            e.preventDefault();
+                          }}
+                        >
+                          ...
+                        </a>
+                      </li>
+                      <li className="page-item">
+                        <a
+                          className={`page-link rounded-1 p-0 ${currentPage === index + 1 && "active"
+                            }`}
+                          href="#"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            setCurrentPage(index + 1);
+                          }}
+                        >
+                          {index + 1}
+                        </a>
+                      </li>
+                    </Fragment>
+                  );
+                else if (currentPage > 3 && index === 0)
+                  return (
+                    <Fragment key={index}>
+                      <li className="page-item">
+                        <a
+                          className={`page-link rounded-1 p-0 ${currentPage === index + 1 && "active"
+                            }`}
+                          href="#"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            setCurrentPage(index + 1);
+                          }}
+                        >
+                          {index + 1}
+                        </a>
+                      </li>
+                      <li className="page-item">
+                        <a
+                          className={`page-link rounded-1 p-0`}
+                          href="#"
+                          onClick={(e) => {
+                            e.preventDefault();
+                          }}
+                        >
+                          ...
+                        </a>
+                      </li>
+                    </Fragment>
+                  );
+              })}
+              <li className="page-item">
+                <a
+                  className={`page-link material-symbols-outlined rounded-1 p-0 ${currentPage === Math.ceil(collectionData.length / 10) &&
+                    "disabled"
+                    }`}
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setCurrentPage(currentPage + 1);
+                  }}
+                >
+                  arrow_forward_ios
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </>
+      )}
     </>
   );
 };

--- a/src/page/AdminPage/AdminCollection.jsx
+++ b/src/page/AdminPage/AdminCollection.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState,Fragment} from "react";
 import { useSelector } from "react-redux";
 import axios from "axios";
 const { VITE_API_BASE_URL } = import.meta.env;
@@ -9,7 +9,7 @@ import LoadingSpinner from '../../component/LoadingSpinner/LoadingSpinner';
 
 
 const AdminCollection = () => {
-  const { isAuthorized, id, username, token } = useSelector(state => state.auth);
+  const { token } = useSelector(state => state.auth);
   const [isLoading, setIsLoading] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [collectionData, setCollectionData] = useState([]);
@@ -33,7 +33,7 @@ const AdminCollection = () => {
         setIsLoading(false);
       };
     })();
-  }, []);
+  }, [token]);
   return (
     <>
       {isLoading && <LoadingSpinner />}
@@ -49,9 +49,9 @@ const AdminCollection = () => {
                 <Admin_ArticleCard
                   key={item.id}
                   collectionData={item}
-                  setCollectionData={setCollectionData} 
-                  collectionDataList={collectionData}  
-                  setCurrentPage={setCurrentPage}     
+                  setCollectionData={setCollectionData}
+                  collectionDataList={collectionData}
+                  setCurrentPage={setCurrentPage}
                 />
               )
             })
@@ -60,7 +60,7 @@ const AdminCollection = () => {
           {/* 分頁 */}
           <nav className="d-none d-lg-block" aria-label="Page navigation">
             <ul className="hot-article-pagination pagination justify-content-center gap-2 mb-0">
-              <li className="page-item" disable="true">
+              <li className="page-item">
                 <a
                   className={`page-link material-symbols-outlined p-0 ps-1 pt-1 rounded-1 ${currentPage === 1 && "disabled"
                     }`}

--- a/src/page/AdminPage/AdminInfo.jsx
+++ b/src/page/AdminPage/AdminInfo.jsx
@@ -19,7 +19,9 @@ const AdminInfo = () => {
   const [selectedFile, setSelectedFile] = useState(null);
   const fileInputRef = useRef(null);
 
-  const { register, handleSubmit, setValue, watch } = useForm();
+  const { register, handleSubmit, setValue, watch,formState:{errors} } = useForm({
+    mode:'onChange'
+  });
   useEffect(() => {
     (async () => {
       if (!token) {
@@ -130,11 +132,26 @@ const AdminInfo = () => {
             </div>
             <div className="mb-5 admin-form_group">
               <label htmlFor="email" className="form-label mb-2">電子郵件</label>
-              <input type="email" className="form-control py-3" id="email" placeholder="email" {...register("email")} />
+              <div><input type="email" className="form-control py-3" id="email" placeholder="email" {...register("email",{
+                pattern: {
+                  value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+                  message: "Email格式不符"
+                }
+              })} />
+            <div className="text-danger mt-1">{errors.email ? errors.email.message : ""}</div>
+              </div>
             </div>
             <div className="mb-5 admin-form_group">
               <label htmlFor="phone" className="form-label mb-2">手機號碼</label>
-              <input type="number" className="form-control py-3" id="phone" placeholder="電話" {...register("phone")} />
+              <div>
+              <input type="text" className="form-control py-3" id="phone" placeholder="電話" {...register("phone",{
+                pattern: {
+                  value: /^\d+$/,
+                  message: "請輸入正確號碼"
+                }
+              })} />
+              <div className="text-danger mt-1">{errors.phone ? errors.phone.message : ""}</div>
+              </div>
             </div>
             <div className="admin-form_group py-md-3 mb-5">
               <p className="mb-md-0 mb-2">性別</p>
@@ -184,8 +201,8 @@ const AdminInfo = () => {
           <p className="mb-md-0 mb-2">生日</p>
           <div className="admin-form_birthday d-flex gap-3 w-md-100">
             <select className="form-select py-3" {...register("year")}>
-              {[...Array(46)].map((_, i) => {
-                const year = 1980 + i;
+              {[...Array(100)].map((_, i) => {
+                const year = 1926 + i;
                 return <option key={year} value={year}>{year}</option>;
               })}
             </select>

--- a/src/page/AdminPage/AdminInfo.jsx
+++ b/src/page/AdminPage/AdminInfo.jsx
@@ -14,13 +14,21 @@ import LoadingSpinner from '../../component/LoadingSpinner/LoadingSpinner';
 const AdminInfo = () => {
   const [isLoading,setIsLoading] = useState(false);
   const dispatch = useDispatch();
-  const { isAuthorized, id, username, token, userAvatar } = useSelector(state => state.auth);
+  const { id, token} = useSelector(state => state.auth);
   const [previewImage, setPreviewImage] = useState("");
   const [selectedFile, setSelectedFile] = useState(null);
   const fileInputRef = useRef(null);
 
   const { register, handleSubmit, setValue, watch,formState:{errors} } = useForm({
-    mode:'onChange'
+    mode:'onChange',
+    defaultValues: {
+      username: "",
+      email: "",
+      phone: "",
+      gender: "",
+      bio: "",
+      profile_picture: "",
+    }
   });
   useEffect(() => {
     (async () => {
@@ -54,7 +62,7 @@ const AdminInfo = () => {
         setIsLoading(false);
       }
     })();
-  }, []);
+  }, [id,setValue,token]);
 
   const handleImageChange = (e) => {
     const file = e.target.files[0];

--- a/src/page/AdminPage/AdminLayout/AdminLayout.jsx
+++ b/src/page/AdminPage/AdminLayout/AdminLayout.jsx
@@ -28,7 +28,7 @@ const AdminLayout = () => {
               <div className="admin_wrap pt-10 pb-5 px-5 rounded-3 border border-gray_light">
                 <div className="admin-mobile-header d-md-none">
                   <div className="d-flex align-items-center flex-column border-bottom border-gray_light mb-5">
-                    <img className="admin-avatar mb-2" src={userAvatar || "https://raw.githubusercontent.com/wfox5510/wordSapce-imgRepo/695229fa8c60c474d3d9dc0d60b25f9539ac74d9/default-avatar.svg"} alt="avatar" />
+                    <img className="admin-avatar mb-2 rounded-circle" src={userAvatar || "https://raw.githubusercontent.com/wfox5510/wordSapce-imgRepo/695229fa8c60c474d3d9dc0d60b25f9539ac74d9/default-avatar.svg"} alt="avatar" />
                     <p className="mb-2">{username}</p>
                     <p className="text-primary mb-5">編輯個人主頁</p>
                   </div>

--- a/src/page/AdminPage/AdminLayout/AdminLayout.jsx
+++ b/src/page/AdminPage/AdminLayout/AdminLayout.jsx
@@ -2,8 +2,7 @@ import { Outlet, NavLink,Link } from "react-router-dom";
 import { useSelector } from "react-redux";
 
 const AdminLayout = () => {
-  const { isAuthorized, id, username, token, userAvatar } = useSelector(state => state.auth);
-  const adminLinkActive = ({ isActive }) => (isActive ? "adminLinkActive" : "");
+  const { id, username,  userAvatar } = useSelector(state => state.auth);
   return (
     <>
       <main className="bg-secondary py-10">

--- a/src/page/AdminPage/AdminLayout/AdminLayout.jsx
+++ b/src/page/AdminPage/AdminLayout/AdminLayout.jsx
@@ -30,7 +30,7 @@ const AdminLayout = () => {
                   <div className="d-flex align-items-center flex-column border-bottom border-gray_light mb-5">
                     <img className="admin-avatar mb-2 rounded-circle" src={userAvatar || "https://raw.githubusercontent.com/wfox5510/wordSapce-imgRepo/695229fa8c60c474d3d9dc0d60b25f9539ac74d9/default-avatar.svg"} alt="avatar" />
                     <p className="mb-2">{username}</p>
-                    <p className="text-primary mb-5">編輯個人主頁</p>
+                    <Link to={`/blog/${id}`} className="text-primary mb-5">編輯個人主頁</Link>
                   </div>
                   <nav className="list-unstyled d-flex justify-content-between admin-layout_nav mb-6">
                     <NavLink to="info" className={({ isActive }) => `pb-1 link-gray ${isActive ? "adminLinkActive" : ""}`}>會員資訊</NavLink>

--- a/src/page/AdminPage/AdminSubscription.jsx
+++ b/src/page/AdminPage/AdminSubscription.jsx
@@ -32,14 +32,13 @@ const AdminSubscription = () => {
         <h1 className="fs-4 fs-md-1 text-primary fw-bold mb-5 mb-md-10">
           收款紀錄
         </h1>
-        <a href="#" className="link-primary-hover">
+        <a style={{cursor:"pointer"}} className="link-primary-hover">
           問題回報
         </a>
       </div>
 
       <div className="subscription-history">
         {paymentReceivedData
-          // .slice((currentPage - 1) * 10 + 1, currentPage * 10)
           .slice((currentPage - 1) * 10 , currentPage * 10)
           .map((paymentReceivedDataItem) => {
             return (


### PR DESCRIPTION
### AdminLayout 
- 行動版大頭照改為圓形外框
- 行動版加入"編輯個人主頁"連結

### AdminInfo 
- 表單加入格式驗證
- 生日年分範圍加寬
- _select為mac ui設計關係，導致滿版，windows顯示為下拉選單_
![螢幕擷取畫面 2025-03-20 232906](https://github.com/user-attachments/assets/f2823f8c-0bf9-4b57-95a3-46a1f6367f06)

### AdminCollection
- 加入分頁(10筆一頁)

### AdminSubscription
- 金額區塊固定寬度
- 問題回報暫時移除連結

### AdminBackground
- 觀看紀錄導入元件

### 修正會員各頁面ESLint錯誤

_收藏問題因牽涉到其他頁面，目前未改動，待大家討論_
