### PR TITLE
修正Blog主頁異常狀態跟部分功能微調，細節可以看pr陳述。

### DIFF
--- a/src/component/BlogPageArticleCard/Blog_ArticleCard.jsx
+++ b/src/component/BlogPageArticleCard/Blog_ArticleCard.jsx
@@ -4,7 +4,7 @@ import axios from "axios";
 import { useEffect, useState, useCallback } from "react";
 import { Link } from "react-router-dom";
 import dayjs from "dayjs";
-import { alertDeletePost, alertMsgForAdminInfo, alertReply } from "../../utils/alertMsg"
+import { alertDeletePost, alertMsgForAdminInfo, alertReply, alertConfirmDeletePost } from "../../utils/alertMsg"
 import Swal from "sweetalert2";
 import { logError } from "../../utils/sentryHelper";
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
@@ -101,19 +101,31 @@ const Blog_ArticleCard = ({ article, comments, togglePin, isPinned, token, getBl
 
   // 文章刪除modal功能
   const articleDelete = async(post_id)=> {
-    try {
-      setIsLoading(true);
-      await axios.delete(`${API_BASE_URL}/posts/${post_id}`,{
-        headers: {
-          Authorization: `Bearer ${token}`,
-        }
-      });
-      setIsLoading(false);
-      Swal.fire(alertDeletePost);
-      getBlogArticle();
-      
-    } catch (error) {
-      logError("文章刪除失敗", error);
+
+    const result = await Swal.fire(alertConfirmDeletePost);
+
+    if (result.isConfirmed) {
+      try {
+        setIsLoading(true);
+        await axios.delete(`${API_BASE_URL}/posts/${post_id}`,{
+          headers: {
+            Authorization: `Bearer ${token}`,
+          }
+        });
+        setIsLoading(false);
+        Swal.fire(alertDeletePost);
+        getBlogArticle();
+        
+      } catch (error) {
+        logError("文章刪除失敗", error);
+        Swal.fire({
+          title: "刪除失敗",
+          text: "發生錯誤, 無法刪除文章。",
+          icon: "error",
+          confirmButtonColor: "#E77605",
+          confirmButtonText: "確定"
+        });
+      }
     }
   }
 

--- a/src/component/BlogPageCommentReply/Blog_CommentReply.jsx
+++ b/src/component/BlogPageCommentReply/Blog_CommentReply.jsx
@@ -157,6 +157,7 @@ const deleteComment = async (commentId) => {
           <span
             className="material-symbols-outlined input-group-text border-start-0 bg-light text-primary icon-fill fs-6 rounded-1 "
             onClick={editComment}
+            style={{ cursor: "pointer" }}
           >
             check_circle
           </span>
@@ -167,6 +168,7 @@ const deleteComment = async (commentId) => {
               setIsEditing(false);
               setEditedReply(comment.content); // 取消時恢復原始內容
             }}
+            style={{ cursor: "pointer" }}
           >
             cancel
           </span>
@@ -284,6 +286,7 @@ const deleteComment = async (commentId) => {
                 formatTimeAgo={formatTimeAgo} // ✅ 傳遞時間函式給子回覆
                 isAuthor={isAuthor}  // ✅ 確保 `isAuthor` 被傳遞
                 userId={userId}      // ✅ 傳遞 userId 判斷編輯權限
+                setIsLoading={setIsLoading}
               />
             )
           )}
@@ -311,7 +314,7 @@ Blog_CommentReply.propTypes = {
   formatTimeAgo: PropTypes.func,
   isAuthor:PropTypes.bool,
   userId: PropTypes.string,
-  setIsLoading: PropTypes.func
+  setIsLoading: PropTypes.func.isRequired, // ✅ 標記為必須提供
 };
 
 

--- a/src/page/BlogPage/BlogHome.jsx
+++ b/src/page/BlogPage/BlogHome.jsx
@@ -103,13 +103,6 @@ const BlogHome = () => {
   }, [user_id, userId]);
 
 
-  //取得釘選文章api資料
-  useEffect(() => {
-    if (user_id) {
-      fetchPinnedArticles();
-    }
-  }, [user_id, fetchPinnedArticles]);  
-
   const fetchPinnedArticles = useCallback(async () => {
     try {
       const res = await axios.get(`${API_BASE_URL}/posts/pinned/${user_id}`);
@@ -119,6 +112,16 @@ const BlogHome = () => {
       setPinnedArticles([]);
     }
   }, [user_id]);
+
+
+  //取得釘選文章api資料
+  useEffect(() => {
+    if (user_id) {
+      fetchPinnedArticles();
+    }
+  }, [user_id, fetchPinnedArticles]);  
+
+
   
 
   // 切換釘選狀態

--- a/src/utils/alertMsg.js
+++ b/src/utils/alertMsg.js
@@ -76,3 +76,14 @@ export const alertMsgForSuccess = {
   showConfirmButton: false,
   timer: 1500,
 };
+
+export const alertConfirmDeletePost = {
+  title: "確定要刪除這篇文章嗎？",
+  text: "刪除後將無法復原！",
+  icon: "warning",
+  showCloseButton: true,
+  showCancelButton: true,
+  confirmButtonColor: "#E77605",
+  confirmButtonText: "確定",
+  cancelButtonText: "取消",
+};


### PR DESCRIPTION
1. 修正文章列表區子留言，無法編輯留言狀況。
2. 新增刪除 Blog 文章前，加上 Sweetalert isConfirmed 先跟使用者確認，待使用者確定再做刪除唷，也能避免誤刪。
3. 修正BlogHome初始化問題。
4. 修改編輯留言框確定跟刪除icon改成滑鼠點擊模式不是輸入鼠標。
